### PR TITLE
Fix cross-platform build issues

### DIFF
--- a/src/functiontypes.cpp
+++ b/src/functiontypes.cpp
@@ -13,6 +13,7 @@
 #include "functiontypes.h"
 #include "util.h"
 #include <assert.h>
+#include <cstring>
 
 namespace unassemblize
 {

--- a/src/imguiclient/processedstate.cpp
+++ b/src/imguiclient/processedstate.cpp
@@ -45,7 +45,7 @@ span<const IndexT> ProcessedState::get_processed_items(size_t begin, size_t end)
     assert(begin <= end);
     assert(end <= m_processedItems.size());
 
-    return span<const IndexT>{m_processedItems.data() + begin, m_processedItems.data() + end};
+    return span<const IndexT>(m_processedItems.data() + begin, end - begin);
 }
 
 span<const IndexT> ProcessedState::get_items_for_processing(span<const IndexT> items)

--- a/src/imguiclient/processedstate.h
+++ b/src/imguiclient/processedstate.h
@@ -15,6 +15,7 @@
 
 #include "commontypes.h"
 #include "util/bitarray.h"
+#include <vector>
 
 namespace unassemblize::gui
 {

--- a/src/options.h
+++ b/src/options.h
@@ -17,7 +17,7 @@
 #include <string_view>
 
 // When output is set to "auto", then output name is chosen for input file name.
-inline constexpr char *const auto_str = "auto";
+inline constexpr const char *const auto_str = "auto";
 bool is_auto_str(const std::string &str);
 
 enum class InputType
@@ -27,7 +27,7 @@ enum class InputType
     None,
 };
 
-inline constexpr char *const s_input_type_names[] = {"exe", "pdb", "none"};
+inline constexpr const char *const s_input_type_names[] = {"exe", "pdb", "none"};
 
 std::string get_config_file_name(const std::string &input_file, const std::string &config_file);
 std::string get_asm_output_file_name(const std::string &input_file, const std::string &output_file);

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -567,7 +567,7 @@ NamedFunctionBundle Runner::build_bundle(
     const Address64ToIndexMapT &named_function_to_index_map,
     uint8_t flags)
 {
-    const SourceInfoVectorT::value_type &source = sources[source_idx];
+    const typename SourceInfoVectorT::value_type &source = sources[source_idx];
     const IndexT function_count = source.functionIds.size();
     NamedFunctionBundle bundle;
     bundle.id = source_idx;

--- a/src/util.h
+++ b/src/util.h
@@ -12,6 +12,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -110,7 +111,7 @@ bool push_back_unique(Container &container, const Value &value)
 template<typename Container, typename Value>
 bool find_and_erase(Container &container, const Value &value)
 {
-    Container::iterator it = std::find(container.begin(), container.end(), value);
+    typename Container::iterator it = std::find(container.begin(), container.end(), value);
     if (it != container.end())
     {
         container.erase(it);
@@ -122,7 +123,7 @@ bool find_and_erase(Container &container, const Value &value)
 template<typename Container, typename UnaryPred>
 bool find_and_erase_if(Container &container, UnaryPred pred)
 {
-    Container::iterator it = std::find_if(container.begin(), container.end(), pred);
+    typename Container::iterator it = std::find_if(container.begin(), container.end(), pred);
     if (it != container.end())
     {
         container.erase(it);


### PR DESCRIPTION
This PR fixes several cross-platform build issues found when building on Linux:

1. Add missing cstring include for memcpy
2. Add missing vector include
3. Fix string literal warnings by using const char*
4. Fix typename keyword for dependent types
5. Fix span constructor usage

These changes allow the project to build successfully on Linux while maintaining Windows compatibility.